### PR TITLE
Improvements from code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ codecov.yml
 pkgdown
 *.swp
 tmp
+tests/testthat/Rplots.pdf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pnpmisc
 Type: Package
 Title: Utilities for Print-and-Play Board Games
-Version: 0.2.0-20
+Version: 0.2.0-21
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")))
@@ -31,6 +31,6 @@ Suggests:
 SystemRequirements: Several features require `ghostscript`.  To make N-up pdf documents you'll also need `pdfxup`.
 License: MIT + file LICENSE
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 Encoding: UTF-8
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              comment = c(ORCID = "0000-0001-6341-4639")))
 URL: https://github.com/trevorld/pnpmisc, https://trevorldavis.com/R/pnpmisc/dev/
 BugReports: https://github.com/trevorld/pnpmisc/issues
-Description: Utilities for print-and-play board games.
+Description: Functions for creating and editing PDF files for print-and-play board games with a consistent interface in which the input filename is the first argument, the output filename is the second, and all other arguments are named.  Includes functions to resize, scale, rotate, and combine PDF pages, add crop marks, crosshairs, and origami fold guides, and create plastic storage box jackets and origami card wallets. Also provides layout functions for splitting pages into individual component images and reassembling them.  Wraps PDF functionality from 'qpdf', 'pdftools', and 'xmpdf' and optionally uses 'ghostscript', 'pdfxup', and 'bittermelon' for additional functionality.
 Depends:
 	R (>= 4.2)
 Imports:

--- a/R/bm_crop_layout.R
+++ b/R/bm_crop_layout.R
@@ -33,7 +33,7 @@ bm_crop_layout <- function(
 	check_dots_empty()
 	stopifnot(
 		requireNamespace("bittermelon", quietly = TRUE),
-		bittermelon::is_bm_pixmap(page),
+		"`page` must be a bm_pixmap object" = bittermelon::is_bm_pixmap(page),
 		is.null(name) || (missing(row) && missing(col))
 	)
 	if (is.character(layout)) {
@@ -41,8 +41,10 @@ bm_crop_layout <- function(
 	}
 	if (is.null(name) || !hasName(layout, "name")) {
 		index <- which(layout$row == row & layout$col == col)
+		stopifnot("`row`/`col` not found in `layout`" = length(index) > 0L)
 	} else {
 		index <- which(layout$name == name)
+		stopifnot("`name` not found in `layout`" = length(index) > 0L)
 	}
 	rows <- bm_card_rows(page, layout = layout, index = index, bleed = bleed)
 	cols <- bm_card_cols(page, layout = layout, index = index, bleed = bleed)

--- a/R/bm_split_layout.R
+++ b/R/bm_split_layout.R
@@ -31,8 +31,10 @@ bm_split_layout <- function(
 	}
 	stopifnot(
 		requireNamespace("bittermelon", quietly = TRUE),
-		bittermelon::is_bm_pixmap(page)
+		"`page` must be a bm_pixmap object" = bittermelon::is_bm_pixmap(page)
 	)
+	# Sort by name so components are returned in reading order rather than
+	# physical layout order (e.g. zine booklet pages become page_1, page_2, ...).
 	if (hasName(layout, "name")) {
 		layout <- layout[order(layout$name), ]
 	}

--- a/R/grid_add_layout.R
+++ b/R/grid_add_layout.R
@@ -53,6 +53,12 @@ grid_add_layout <- function(images, ..., layout = "poker_3x3") {
 			pushViewport(vp)
 			grid.draw(image)
 			popViewport()
+		} else {
+			abort(sprintf(
+				"Image %s must be a supported bitmap or grob but got class %s.",
+				dQuote(n),
+				dQuote(class(image)[[1L]])
+			))
 		}
 	}
 	invisible(NULL)

--- a/R/layout.R
+++ b/R/layout.R
@@ -36,9 +36,12 @@ layout_grid <- function(
 
 	is_ltr <- tolower(direction) %in% c("left-to-right", "ltr", "lr")
 	is_rtl <- tolower(direction) %in% c("right-to-left", "rtl", "rl")
-	stopifnot(is_ltr || is_rtl)
+	stopifnot("`direction` must be \"left-to-right\" or \"right-to-left\"" = is_ltr || is_rtl)
 
-	stopifnot(nrow > 0L, ncol > 0L)
+	stopifnot(
+		"`nrow` must be a positive integer" = nrow > 0L,
+		"`ncol` must be a positive integer" = ncol > 0L
+	)
 
 	xc <- 0.5 * paper_width(paper, orientation)
 	yc <- 0.5 * paper_height(paper, orientation)
@@ -80,12 +83,15 @@ layout_grid <- function(
 	if (is.function(name)) {
 		name <- name(nrow, ncol)
 	} else {
-		stopifnot(length(name) == nrow * ncol, !anyDuplicated(name))
+		stopifnot(
+			"`name` must have length `nrow * ncol`" = length(name) == nrow * ncol,
+			"`name` must not contain duplicates" = !anyDuplicated(name)
+		)
 	}
 	if (is_rtl) {
 		name <- assign_rtl(name, nrow)
 		if (length(angle) > 1L) {
-			stopifnot(length(angle) == nrow * ncol)
+			stopifnot("`angle` must have length `nrow * ncol`" = length(angle) == nrow * ncol)
 			angle <- assign_rtl(angle, nrow)
 		}
 	}

--- a/R/pdf_add_cropmarks.R
+++ b/R/pdf_add_cropmarks.R
@@ -70,8 +70,7 @@ grid_add_cropmarks <- function(
 	cm_width = unit(0.25, "mm"),
 	cm_length = unit(0.125, "in")
 ) {
-	stopifnot(requireNamespace("piecepackr", quietly = TRUE))
-	stopifnot(packageVersion("piecepackr") >= "1.14.0-6")
+	stopifnot(has_namespace("piecepackr", "1.14.0-6"))
 	if (is.character(layout)) {
 		layout <- layout_preset(layout)
 	}

--- a/R/pdf_add_crosshairs.R
+++ b/R/pdf_add_crosshairs.R
@@ -67,8 +67,7 @@ grid_add_crosshairs <- function(
 	ch_width = unit(1 / 6, "in"),
 	ch_grob = NULL
 ) {
-	stopifnot(requireNamespace("piecepackr", quietly = TRUE))
-	stopifnot(packageVersion("piecepackr") >= "1.14.0-5")
+	stopifnot(has_namespace("piecepackr", "1.14.0-5"))
 	ch_grob <- ch_grob %||% piecepackr::squaresCrosshairGrob()
 	if (is.character(layout)) {
 		layout <- layout_preset(layout)

--- a/R/pdf_apply.R
+++ b/R/pdf_apply.R
@@ -280,6 +280,8 @@ pdf_apply_raster <- function(
 	if (scale != 1 && !identical(grid_fn, grid::grid.null)) {
 		old_w <- df_size_orig$width[1L]
 		old_h <- df_size_orig$height[1L]
+		# Record the grob in the original (pre-scale) viewport so that when
+		# grid.use() applies the affine viewportTransform below it scales correctly.
 		overlay_grob <- recordGrob(
 			grid_fn(),
 			list(grid_fn = grid_fn),

--- a/R/pdf_pages.R
+++ b/R/pdf_pages.R
@@ -3,7 +3,6 @@
 #' `pdf_pages()` calculates an integer vector of subset of pdf pages.
 #'
 #' @inheritParams pdf_apply
-#' @inheritParams pdf_apply
 #' @examples
 #' f <- pdf_create_blank(length = 8L)
 #' pdf_pages(f, pages = 1:4)
@@ -32,7 +31,7 @@ pdf_pages <- function(
 	)
 ) {
 	check_dots_empty()
-	stopifnot(is.numeric(pages) || is.character(pages))
+	stopifnot("`pages` must be numeric or character" = is.numeric(pages) || is.character(pages))
 	n <- qpdf::pdf_length(input)
 	if (is.numeric(pages)) {
 		pages <- seq.int(n)[pages]
@@ -67,7 +66,12 @@ pages_interleave_last <- function(n) {
 }
 
 pages_2up_saddle_stitch <- function(n) {
-	stopifnot(n > 0L, n %% 4L == 0L)
+	if (n %% 4L != 0L) {
+		abort(sprintf(
+			'"2-up saddle stitch" requires a number of pages divisible by 4 but got %d.',
+			n
+		))
+	}
 	x <- seq.int(n)
 	pages <- integer(0L)
 	while (length(x) > 0L) {

--- a/R/pdf_paper.R
+++ b/R/pdf_paper.R
@@ -19,12 +19,16 @@ pdf_paper <- function(input) {
 	short <- pmin(width, height)
 	long <- pmax(width, height)
 	paper <- rep_len("special", length(height))
-	paper <- ifelse(abs(short - 2.25) < 5e-2 & abs(long - 3.5) < 5e-2, "bridge", paper)
-	paper <- ifelse(abs(short - 2.5) < 5e-2 & abs(long - 3.5) < 5e-2, "poker", paper)
-	paper <- ifelse(abs(short - 8.5) < 5e-2 & abs(long - 14) < 5e-2, "legal", paper)
-	paper <- ifelse(abs(short - 8.5) < 5e-2 & abs(long - 11) < 5e-2, "letter", paper)
-	paper <- ifelse(abs(short - 11.69) < 5e-2 & abs(long - 16.54) < 5e-2, "a3", paper)
-	paper <- ifelse(abs(short - 8.27) < 5e-2 & abs(long - 11.69) < 5e-2, "a4", paper)
-	paper <- ifelse(abs(short - 5.83) < 5e-2 & abs(long - 8.27) < 5e-2, "a5", paper)
+	# PDFs store dimensions as integer bigpts, so the inch round-trip introduces
+	# quantization error (~0.007 in for A4). 5e-2 is the tightest value that
+	# passes tests for all supported paper sizes.
+	tol <- 5e-2
+	paper <- ifelse(abs(short - 2.25) < tol & abs(long - 3.5) < tol, "bridge", paper)
+	paper <- ifelse(abs(short - 2.5) < tol & abs(long - 3.5) < tol, "poker", paper)
+	paper <- ifelse(abs(short - 8.5) < tol & abs(long - 14) < tol, "legal", paper)
+	paper <- ifelse(abs(short - 8.5) < tol & abs(long - 11) < tol, "letter", paper)
+	paper <- ifelse(abs(short - 11.69) < tol & abs(long - 16.54) < tol, "a3", paper)
+	paper <- ifelse(abs(short - 8.27) < tol & abs(long - 11.69) < tol, "a4", paper)
+	paper <- ifelse(abs(short - 5.83) < tol & abs(long - 8.27) < tol, "a5", paper)
 	paper
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,7 +26,7 @@ normalize_output <- function(output, input = NULL) {
 	output <- normalizePath(output, mustWork = FALSE)
 	if (!is.null(input)) {
 		input <- normalizePath(input, mustWork = TRUE)
-		stopifnot(input != output)
+		stopifnot("`input` and `output` must be different files" = input != output)
 	}
 	output
 }
@@ -90,7 +90,12 @@ pnp_pdf <- function(
 	bg = "white"
 ) {
 	paper <- tolower(paper)
-	stopifnot(paper %in% SUPPORTED_PAPER)
+	if (!paper %in% SUPPORTED_PAPER) {
+		abort(sprintf(
+			"`paper` must be one of %s.",
+			paste(dQuote(SUPPORTED_PAPER), collapse = ", ")
+		))
+	}
 	if (missing(width) && missing(height) && paper != "special") {
 		orientation <- match.arg(orientation)
 		width <- paper_width(paper, orientation)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -110,15 +110,22 @@ pnp_pdf <- function(
 
 # Adapted from `xmpdf:::xmpdf_system2()`
 system2_cmd <- function(cmd, args) {
-	output <- system2(cmd, args, stdout = TRUE, stderr = FALSE)
+	stderr_file <- tempfile()
+	on.exit(unlink(stderr_file), add = TRUE)
+	output <- system2(cmd, args, stdout = TRUE, stderr = stderr_file)
 	if (!is.null(attr(output, "status"))) {
-		abort(paste(sQuote("system2()"), "command failed."))
+		abort(c(paste(sQuote("system2()"), "command failed."), readLines(stderr_file)))
 	}
 	invisible(output)
 }
 
+has_namespace <- function(pkg, version = NULL) {
+	requireNamespace(pkg, quietly = TRUE) &&
+		(is.null(version) || packageVersion(pkg) >= version)
+}
+
 is_supported_bitmap <- function(x) {
-	if (requireNamespace("bittermelon") && packageVersion("bittermelon") >= "2.2.0") {
+	if (has_namespace("bittermelon", "2.2.0")) {
 		bittermelon::is_supported_bitmap(x)
 	} else {
 		inherits(x, c("bm_bitmap", "bm_pixmap", "magick-image", "nativeRaster", "raster"))

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,7 @@ development:
     mode: auto
 template:
   bootstrap: 5
+llm-docs: false
 reference:
     - title: "Edit PDF files"
       desc: 'The first positional argument is always the `input` pdf and the second positional argument is the `output` pdf (which always defaults to `tempfile(fileext=".pdf")`).  Returns the `output` pdf invisibly.'

--- a/man/fullGrob.Rd
+++ b/man/fullGrob.Rd
@@ -20,22 +20,22 @@ grid.full(...)
 as_fill(fill = "transparent", ..., width = NULL, height = NULL)
 }
 \arguments{
-\item{fill}{A color string, a \code{\link[grid:grid.grob]{grid::grob()}}, a \code{\link[grid:patterns]{grid::pattern()}}, or a bitmap like a \code{\link[bittermelon:bm_pixmap]{bittermelon::bm_pixmap()}} or raster object.}
+\item{fill}{A color string, a \code{\link[grid:grob]{grid::grob()}}, a \code{\link[grid:pattern]{grid::pattern()}}, or a bitmap like a \code{\link[bittermelon:bm_pixmap]{bittermelon::bm_pixmap()}} or raster object.}
 
 \item{...}{Ignored for now.}
 
-\item{width, height}{If \code{fill} is a bitmap object then these will be passed to \code{\link[grid:grid.raster]{grid::rasterGrob()}}.}
+\item{width, height}{If \code{fill} is a bitmap object then these will be passed to \code{\link[grid:rasterGrob]{grid::rasterGrob()}}.}
 
-\item{vp, name}{Passed to \code{\link[grid:grid.rect]{grid::rectGrob()}}.}
+\item{vp, name}{Passed to \code{\link[grid:rectGrob]{grid::rectGrob()}}.}
 }
 \value{
-\code{fullGrob()} and \code{grid.full()} return \code{\link[grid:grid.rect]{grid::rectGrob()}} object.
+\code{fullGrob()} and \code{grid.full()} return \code{\link[grid:rectGrob]{grid::rectGrob()}} object.
 As a side effect \code{grid.full()} draws to the active graphics device.  \code{as_fill()} returns a supported grid fill object such as a color string or a \code{grid::pattern()} object.
 }
 \description{
-\code{fullGrob()} is a wrapper around \code{\link[grid:grid.rect]{grid::rectGrob()}} for a single
+\code{fullGrob()} is a wrapper around \code{\link[grid:rectGrob]{grid::rectGrob()}} for a single
 rectangle grob filled with a color, bitmap, grob, or pattern.
-In particular grob or bitmap fills will be automatically converted to a \code{\link[grid:patterns]{grid::pattern()}} fill by \code{as_fill()}.
+In particular grob or bitmap fills will be automatically converted to a \code{\link[grid:pattern]{grid::pattern()}} fill by \code{as_fill()}.
 \code{grid.full()} creates a \code{fullGrob()} and draws it to the screen.
 }
 \examples{

--- a/man/grid_add_crosshairs.Rd
+++ b/man/grid_add_crosshairs.Rd
@@ -19,7 +19,7 @@ grid_add_crosshairs(
 with layout data (as returned by \code{\link[=layout_grid]{layout_grid()}}).}
 
 \item{gp, ch_width, ch_grob}{Passed to \code{\link[piecepackr:grid.crosshair]{piecepackr::grid.crosshair()}}.
-\code{ch_grob} defaults to \code{\link[piecepackr:grid.crosshair]{piecepackr::squaresCrosshairGrob()}}.}
+\code{ch_grob} defaults to \code{\link[piecepackr:squaresCrosshairGrob]{piecepackr::squaresCrosshairGrob()}}.}
 }
 \value{
 \code{NULL} invisibly.

--- a/man/pdf_add_crosshairs.Rd
+++ b/man/pdf_add_crosshairs.Rd
@@ -25,7 +25,7 @@ pdf_add_crosshairs(
 with layout data (as returned by \code{\link[=layout_grid]{layout_grid()}}).}
 
 \item{gp, ch_width, ch_grob}{Passed to \code{\link[piecepackr:grid.crosshair]{piecepackr::grid.crosshair()}}.
-\code{ch_grob} defaults to \code{\link[piecepackr:grid.crosshair]{piecepackr::squaresCrosshairGrob()}}.}
+\code{ch_grob} defaults to \code{\link[piecepackr:squaresCrosshairGrob]{piecepackr::squaresCrosshairGrob()}}.}
 }
 \value{
 \code{output} pdf file name invisibly.

--- a/man/pdf_gs.Rd
+++ b/man/pdf_gs.Rd
@@ -18,7 +18,7 @@ We automatically add \code{-dBATCH -dNOPAUSE -sDEVICE=pdfwrite -sAutoRotatePages
 }
 \description{
 \code{pdf_gs()} processes the pdf file with \code{ghostscript}.
-This may prevent issues with other pdf processing functions like \code{\link[pdftools:pdftools]{pdftools::pdf_pagesize()}}.
+This may prevent issues with other pdf processing functions like \code{\link[pdftools:pdf_pagesize]{pdftools::pdf_pagesize()}}.
 }
 \examples{
 if (nzchar(tools::find_gs_cmd())) {

--- a/man/pnp_pdf.Rd
+++ b/man/pnp_pdf.Rd
@@ -28,7 +28,7 @@ pnp_pdf(
 \item{bg}{\code{output} pdf background color.}
 }
 \description{
-\code{pnp_pdf()} creates a pdf device preferring \code{\link[grDevices:cairo]{grDevices::cairo_pdf()}}
+\code{pnp_pdf()} creates a pdf device preferring \code{\link[grDevices:cairo_pdf]{grDevices::cairo_pdf()}}
 when supported but falling back to \code{\link[grDevices:pdf]{grDevices::pdf()}} when not.
 }
 \keyword{internal}

--- a/man/pnpmisc.Rd
+++ b/man/pnpmisc.Rd
@@ -29,5 +29,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Trevor L. Davis \email{trevor.l.davis@gmail.com} (\href{https://orcid.org/0000-0001-6341-4639}{ORCID})
 
+Authors:
+\itemize{
+  \item Trevor L. Davis \email{trevor.l.davis@gmail.com} (\href{https://orcid.org/0000-0001-6341-4639}{ORCID})
+}
+
 }
 \keyword{internal}

--- a/man/qpdf_wrappers.Rd
+++ b/man/qpdf_wrappers.Rd
@@ -68,6 +68,6 @@ unlink(f6)
 unlink(f7)
 }
 \seealso{
-\code{\link[qpdf:qpdf]{qpdf::pdf_combine()}}, \code{\link[qpdf:qpdf]{qpdf::pdf_compress()}},
-\code{\link[qpdf:qpdf]{qpdf::pdf_overlay_stamp()}}, \code{\link[qpdf:qpdf]{qpdf::pdf_rotate_pages()}}, \code{\link[qpdf:qpdf]{qpdf::pdf_subset()}}
+\code{\link[qpdf:pdf_combine]{qpdf::pdf_combine()}}, \code{\link[qpdf:pdf_compress]{qpdf::pdf_compress()}},
+\code{\link[qpdf:pdf_overlay_stamp]{qpdf::pdf_overlay_stamp()}}, \code{\link[qpdf:pdf_rotate_pages]{qpdf::pdf_rotate_pages()}}, \code{\link[qpdf:pdf_subset]{qpdf::pdf_subset()}}
 }

--- a/man/xmpdf_wrappers.Rd
+++ b/man/xmpdf_wrappers.Rd
@@ -19,11 +19,11 @@ pdf_set_xmp(input, output = NULL, ..., xmp)
 
 \item{...}{Currently ignored.}
 
-\item{bookmarks}{See \code{\link[xmpdf:bookmarks]{xmpdf::set_bookmarks()}}.}
+\item{bookmarks}{See \code{\link[xmpdf:set_bookmarks]{xmpdf::set_bookmarks()}}.}
 
-\item{docinfo}{See \code{\link[xmpdf:edit_docinfo]{xmpdf::set_docinfo()}}.}
+\item{docinfo}{See \code{\link[xmpdf:set_docinfo]{xmpdf::set_docinfo()}}.}
 
-\item{xmp}{See \code{\link[xmpdf:edit_xmp]{xmpdf::set_xmp()}}.}
+\item{xmp}{See \code{\link[xmpdf:set_xmp]{xmpdf::set_xmp()}}.}
 }
 \value{
 \code{output} filename of new pdf file invisibly.
@@ -61,5 +61,5 @@ if (requireNamespace("xmpdf", quietly = TRUE) &&
 unlink(f1)
 }
 \seealso{
-\code{\link[xmpdf:bookmarks]{xmpdf::set_bookmarks()}}, \code{\link[xmpdf:edit_docinfo]{xmpdf::set_docinfo()}}, \code{\link[xmpdf:edit_xmp]{xmpdf::set_xmp()}}
+\code{\link[xmpdf:set_bookmarks]{xmpdf::set_bookmarks()}}, \code{\link[xmpdf:set_docinfo]{xmpdf::set_docinfo()}}, \code{\link[xmpdf:set_xmp]{xmpdf::set_xmp()}}
 }

--- a/tests/testthat/_snaps/bm_crop_layout.md
+++ b/tests/testthat/_snaps/bm_crop_layout.md
@@ -1,0 +1,24 @@
+# `bm_crop_layout()` error paths
+
+    Code
+      bm_crop_layout("not a pixmap", layout = "button_shy_cards")
+    Condition
+      Error in `bm_crop_layout()`:
+      ! `page` must be a bm_pixmap object
+
+---
+
+    Code
+      bm_crop_layout(page, layout = "button_shy_cards", row = 99L, col = 1L)
+    Condition
+      Error in `bm_crop_layout()`:
+      ! `row`/`col` not found in `layout`
+
+---
+
+    Code
+      bm_crop_layout(page, layout = "button_shy_cards", name = "no_such_name")
+    Condition
+      Error in `bm_crop_layout()`:
+      ! `name` not found in `layout`
+

--- a/tests/testthat/_snaps/bm_split_layout.md
+++ b/tests/testthat/_snaps/bm_split_layout.md
@@ -1,0 +1,8 @@
+# `bm_split_layout()` works as expected
+
+    Code
+      bm_split_layout("not a pixmap", layout = "button_shy_rules")
+    Condition
+      Error in `bm_split_layout()`:
+      ! `page` must be a bm_pixmap object
+

--- a/tests/testthat/_snaps/grid_add_layout.md
+++ b/tests/testthat/_snaps/grid_add_layout.md
@@ -1,0 +1,8 @@
+# `grid_add_layout()` errors on unsupported image type
+
+    Code
+      grid_add_layout(list(a = "not an image"), layout = layout)
+    Condition
+      Error in `grid_add_layout()`:
+      ! Image "a" must be a supported bitmap or grob but got class "character".
+

--- a/tests/testthat/_snaps/layout.md
+++ b/tests/testthat/_snaps/layout.md
@@ -1,0 +1,40 @@
+# layout functions
+
+    Code
+      layout_grid(direction = "up")
+    Condition
+      Error in `layout_grid()`:
+      ! `direction` must be "left-to-right" or "right-to-left"
+
+---
+
+    Code
+      layout_grid(nrow = 0L)
+    Condition
+      Error in `layout_grid()`:
+      ! `nrow` must be a positive integer
+
+---
+
+    Code
+      layout_grid(nrow = 2L, ncol = 2L, name = c("a", "b", "c"))
+    Condition
+      Error in `layout_grid()`:
+      ! `name` must have length `nrow * ncol`
+
+---
+
+    Code
+      layout_grid(nrow = 2L, ncol = 2L, name = c("a", "b", "b", "c"))
+    Condition
+      Error in `layout_grid()`:
+      ! `name` must not contain duplicates
+
+---
+
+    Code
+      layout_grid(nrow = 2L, ncol = 2L, direction = "rtl", angle = c(0, 90, 180))
+    Condition
+      Error in `layout_grid()`:
+      ! `angle` must have length `nrow * ncol`
+

--- a/tests/testthat/_snaps/pdf_apply.md
+++ b/tests/testthat/_snaps/pdf_apply.md
@@ -25,6 +25,14 @@
       `bg` is ignored in the vector path when not resizing.
       i Pass `paper` or `scale` to apply `bg`, or `rasterize = TRUE` to force rasterization.
 
+# `pdf_apply()` errors when `input` and `output` are the same file
+
+    Code
+      pdf_apply(f, output = f)
+    Condition
+      Error in `normalize_output()`:
+      ! `input` and `output` must be different files
+
 # `pdf_apply()` errors when `isFALSE(rasterize)` but must rasterize
 
     Code

--- a/tests/testthat/_snaps/pdf_create_blank.md
+++ b/tests/testthat/_snaps/pdf_create_blank.md
@@ -1,0 +1,8 @@
+# `pdf_create_blank()`
+
+    Code
+      pdf_create_blank(paper = "a6")
+    Condition
+      Error in `pnp_pdf()`:
+      ! `paper` must be one of "letter", "a4", "poker", "bridge", "legal", "a5", "a3", "special".
+

--- a/tests/testthat/_snaps/pdf_pages.md
+++ b/tests/testthat/_snaps/pdf_pages.md
@@ -6,3 +6,19 @@
       Error in `pages_interleave()`:
       ! "interleave" requires an even number of pages but got 3.
 
+---
+
+    Code
+      pdf_pages(f3, pages = "2-up saddle stitch")
+    Condition
+      Error in `pages_2up_saddle_stitch()`:
+      ! "2-up saddle stitch" requires a number of pages divisible by 4 but got 3.
+
+---
+
+    Code
+      pdf_pages(f3, pages = list())
+    Condition
+      Error in `pdf_pages()`:
+      ! `pages` must be numeric or character
+

--- a/tests/testthat/test-bm_crop_layout.R
+++ b/tests/testthat/test-bm_crop_layout.R
@@ -1,0 +1,17 @@
+test_that("`bm_crop_layout()` error paths", {
+	skip_if_not_installed("bittermelon")
+	on.exit(rm_temp_pdfs(), add = TRUE)
+
+	f <- pdf_create_blank(orientation = "landscape")
+	page <- pdf_render_bm_pixmap(f, page = 1L)
+
+	expect_snapshot(error = TRUE, bm_crop_layout("not a pixmap", layout = "button_shy_cards"))
+	expect_snapshot(
+		error = TRUE,
+		bm_crop_layout(page, layout = "button_shy_cards", row = 99L, col = 1L)
+	)
+	expect_snapshot(
+		error = TRUE,
+		bm_crop_layout(page, layout = "button_shy_cards", name = "no_such_name")
+	)
+})

--- a/tests/testthat/test-bm_split_layout.R
+++ b/tests/testthat/test-bm_split_layout.R
@@ -6,4 +6,6 @@ test_that("`bm_split_layout()` works as expected", {
 	page <- pdf_render_bm_pixmap(f1, page = 1)
 	bml <- bm_split_layout(page, layout = "button_shy_rules")
 	expect_equal(length(bml), 8L)
+
+	expect_snapshot(error = TRUE, bm_split_layout("not a pixmap", layout = "button_shy_rules"))
 })

--- a/tests/testthat/test-grid_add_layout.R
+++ b/tests/testthat/test-grid_add_layout.R
@@ -13,3 +13,9 @@ test_that("layout functions", {
 
 	expect_equal(qpdf::pdf_length(f2), 1L)
 })
+
+test_that("`grid_add_layout()` errors on unsupported image type", {
+	skip_if_not_installed("bittermelon")
+	layout <- data.frame(name = "a", x = 1, y = 1, width = 1, height = 1, angle = 0)
+	expect_snapshot(error = TRUE, grid_add_layout(list(a = "not an image"), layout = layout))
+})

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -76,4 +76,13 @@ test_that("layout functions", {
 	expect_true(is.data.frame(df))
 	expect_true(all(hasName(df, expected_names)))
 	expect_equal(nrow(df), 25L)
+
+	expect_snapshot(error = TRUE, layout_grid(direction = "up"))
+	expect_snapshot(error = TRUE, layout_grid(nrow = 0L))
+	expect_snapshot(error = TRUE, layout_grid(nrow = 2L, ncol = 2L, name = c("a", "b", "c")))
+	expect_snapshot(error = TRUE, layout_grid(nrow = 2L, ncol = 2L, name = c("a", "b", "b", "c")))
+	expect_snapshot(
+		error = TRUE,
+		layout_grid(nrow = 2L, ncol = 2L, direction = "rtl", angle = c(0, 90, 180))
+	)
 })

--- a/tests/testthat/test-pdf_apply.R
+++ b/tests/testthat/test-pdf_apply.R
@@ -51,6 +51,12 @@ test_that("`pdf_apply()` warns when `bg` is ignored in vector path", {
 	expect_snapshot(pdf_apply(f, bg = "blue", rasterize = FALSE))
 })
 
+test_that("`pdf_apply()` errors when `input` and `output` are the same file", {
+	f <- pdf_create_blank(paper = "letter")
+	on.exit(unlink(f), add = TRUE)
+	expect_snapshot(error = TRUE, pdf_apply(f, output = f))
+})
+
 test_that("`pdf_apply()` errors when `isFALSE(rasterize)` but must rasterize", {
 	on.exit(rm_temp_pdfs(), add = TRUE)
 	f <- pdf_create_blank(paper = "letter", length = 4L)

--- a/tests/testthat/test-pdf_create_blank.R
+++ b/tests/testthat/test-pdf_create_blank.R
@@ -3,4 +3,6 @@ test_that("`pdf_create_blank()`", {
 
 	f <- pdf_create_blank(length = 4L)
 	expect_equal(qpdf::pdf_length(f), 4L)
+
+	expect_snapshot(error = TRUE, pdf_create_blank(paper = "a6"))
 })

--- a/tests/testthat/test-pdf_pages.R
+++ b/tests/testthat/test-pdf_pages.R
@@ -20,4 +20,6 @@ test_that("`pdf_pages()`", {
 
 	f3 <- pdf_create_blank(length = 3L)
 	expect_snapshot(error = TRUE, pdf_pages(f3, pages = "interleave"))
+	expect_snapshot(error = TRUE, pdf_pages(f3, pages = "2-up saddle stitch"))
+	expect_snapshot(error = TRUE, pdf_pages(f3, pages = list()))
 })

--- a/tests/testthat/test-pdf_pdfxup.R
+++ b/tests/testthat/test-pdf_pdfxup.R
@@ -12,7 +12,7 @@ test_that("`pdf_pdfxup()`", {
 
 	n <- qpdf::pdf_length(f1)
 	f2 <- pdf_pdfxup_booklet(f1, paper = "letter")
-	expect_equal(qpdf::pdf_length(f2), ceiling(n / 2L))
+	expect_equal(qpdf::pdf_length(f2), ceiling(n / 4L) * 2L)
 
 	f3 <- pdf_pdfxup_booklet(f1, paper = "letter", pages = 1:4, bb_pages = 1:4)
 	expect_equal(qpdf::pdf_length(f3), 2L)


### PR DESCRIPTION
- **chore: Run `devtools::document()` with new version of {roxygen2}**
  

- **fix: Improve error messages and add error-path snapshot tests**
  Replace bare `stopifnot()` calls with named messages and switch two
  cases to `abort(sprintf(...))` for dynamic content. Add snapshot tests
  to pin all error messages.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **fix: Correct expected page count in `pdf_pdfxup_booklet()` test**
  New R version's Sweave.pdf revealed the original assumption about page
  count was wrong.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **fix: Add input validation and error-path tests to bm_crop/split_layout()**
  Add bounds checking for row/col and name lookups in bm_crop_layout(),
  improve stopifnot() messages in both functions, and add snapshot tests
  for all new error paths.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **fix: Add has_namespace() helper, graceful errors, and clarifying comments**
  - Add has_namespace(pkg, version) helper to zzz.R; use it in
    is_supported_bitmap(), pdf_add_cropmarks(), and pdf_add_crosshairs()
    to collapse two-step requireNamespace/packageVersion checks
  - Add graceful abort() in grid_add_layout() for unsupported image types
  - Add comment in pdf_apply_raster() explaining the pre-scale grob
    recording step
  - Surface stderr output in system2_cmd() on failure
  - Add comment in bm_split_layout() explaining sort-by-name behaviour
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  