### PR TITLE
docs(pdf_change_paper): Document A4/letter scale factors with examples

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@
 ^README.html$
 ^README.rst$
 ^Rakefile$
+^Rplots.pdf$
 ^\.air.toml$
 ^\.claude$
 ^\.editorconfig$

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .claude
 README.html
 codecov.yml
+Rplots.pdf
 pkgdown
 *.swp
 tmp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pnpmisc
 Type: Package
 Title: Utilities for Print-and-Play Board Games
-Version: 0.2.0-21
+Version: 0.2.0-22
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
              email="trevor.l.davis@gmail.com",
              comment = c(ORCID = "0000-0001-6341-4639")))

--- a/R/pdf_change_paper.R
+++ b/R/pdf_change_paper.R
@@ -8,6 +8,16 @@
 #' By default these function do **not** scale the original contents
 #' (but you can pass on a `scale` argument in the `...` to [pdf_apply()]).
 #'
+#' To convert a document between A4 and letter paper without losing any of its
+#' original safe zone, scale by the ratio of the binding dimension
+#' (the dimension that shrinks) rather than leaving `scale` at its default of 1:
+#' \describe{
+#'   \item{A4 to letter}{Height is the binding dimension (letter is shorter than A4),
+#'         so use `scale = 11 / (297 / 25.4)` (about 0.94).}
+#'   \item{Letter to A4}{Width is the binding dimension (A4 is narrower than letter),
+#'         so use `scale = (210 / 25.4) / 8.5` (about 0.97).}
+#' }
+#'
 #' @inheritParams pnp_pdf
 #' @inheritParams pdf_apply
 #' @param ... Passed to [pdf_apply()].
@@ -36,6 +46,30 @@
 #' unlink(output_a4)
 #'
 #' unlink(input)
+#'
+#' # Convert an A4 document to letter, preserving its safe zone
+#' input_a4 <- pdf_create_blank(paper = "a4", bg = "blue")
+#' output_letter <- pdf_change_paper(
+#'   input_a4,
+#'   paper = "letter",
+#'   scale = 11 / (297 / 25.4)
+#' )
+#' pdf_width(output_letter)
+#' pdf_height(output_letter)
+#' unlink(input_a4)
+#' unlink(output_letter)
+#'
+#' # Convert a letter document to A4, preserving its safe zone
+#' input_letter <- pdf_create_blank(paper = "letter", bg = "blue")
+#' output_a4_safe <- pdf_change_paper(
+#'   input_letter,
+#'   paper = "a4",
+#'   scale = (210 / 25.4) / 8.5
+#' )
+#' pdf_width(output_a4_safe)
+#' pdf_height(output_a4_safe)
+#' unlink(input_letter)
+#' unlink(output_a4_safe)
 #' @export
 pdf_change_paper <- function(
 	input,

--- a/man/pdf_change_paper.Rd
+++ b/man/pdf_change_paper.Rd
@@ -41,6 +41,16 @@ to a normal paper size (e.g. padding a pdf smaller than letter to letter size).
 \details{
 By default these function do \strong{not} scale the original contents
 (but you can pass on a \code{scale} argument in the \code{...} to \code{\link[=pdf_apply]{pdf_apply()}}).
+
+To convert a document between A4 and letter paper without losing any of its
+original safe zone, scale by the ratio of the binding dimension
+(the dimension that shrinks) rather than leaving \code{scale} at its default of 1:
+\describe{
+\item{A4 to letter}{Height is the binding dimension (letter is shorter than A4),
+so use \code{scale = 11 / (297 / 25.4)} (about 0.94).}
+\item{Letter to A4}{Width is the binding dimension (A4 is narrower than letter),
+so use \code{scale = (210 / 25.4) / 8.5} (about 0.97).}
+}
 }
 \examples{
 # Some PnP files' size is the intersection of A4/letter page sizes
@@ -65,4 +75,28 @@ pdf_height(output_a4)
 unlink(output_a4)
 
 unlink(input)
+
+# Convert an A4 document to letter, preserving its safe zone
+input_a4 <- pdf_create_blank(paper = "a4", bg = "blue")
+output_letter <- pdf_change_paper(
+  input_a4,
+  paper = "letter",
+  scale = 11 / (297 / 25.4)
+)
+pdf_width(output_letter)
+pdf_height(output_letter)
+unlink(input_a4)
+unlink(output_letter)
+
+# Convert a letter document to A4, preserving its safe zone
+input_letter <- pdf_create_blank(paper = "letter", bg = "blue")
+output_a4_safe <- pdf_change_paper(
+  input_letter,
+  paper = "a4",
+  scale = (210 / 25.4) / 8.5
+)
+pdf_width(output_a4_safe)
+pdf_height(output_a4_safe)
+unlink(input_letter)
+unlink(output_a4_safe)
 }

--- a/man/pnpmisc.Rd
+++ b/man/pnpmisc.Rd
@@ -6,7 +6,7 @@
 \alias{pnpmisc}
 \title{pnpmisc: Utilities for Print-and-Play Board Games}
 \description{
-Utilities for print-and-play board games.
+Functions for creating and editing PDF files for print-and-play board games with a consistent interface in which the input filename is the first argument, the output filename is the second, and all other arguments are named. Includes functions to resize, scale, rotate, and combine PDF pages, add crop marks, crosshairs, and origami fold guides, and create plastic storage box jackets and origami card wallets. Also provides layout functions for splitting pages into individual component images and reassembling them. Wraps PDF functionality from 'qpdf', 'pdftools', and 'xmpdf' and optionally uses 'ghostscript', 'pdfxup', and 'bittermelon' for additional functionality.
 }
 \section{Package options}{
 


### PR DESCRIPTION
Explain which page dimension is binding when converting between A4 and
letter paper, give the corresponding `scale` formula for each direction,
and add a runnable example for each.
